### PR TITLE
Added RedisCache

### DIFF
--- a/build/transforms/web.config.install.xdt
+++ b/build/transforms/web.config.install.xdt
@@ -10,6 +10,8 @@
     <add key="AzureCDNToolkit:MediaContainer" value="media" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
     <add key="AzureCDNToolkit:SecurityModeEnabled" value="false" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
     <add key="AzureCDNToolkit:SecurityToken" value="" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
+    <add key="AzureCDNToolkit:UseRedisCache" value="false" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
+    <add key="AzureCDNToolkit:RedisCacheConnectionString" value="" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
   </appSettings>
 
 </configuration>

--- a/build/transforms/web.config.uninstall.xdt
+++ b/build/transforms/web.config.uninstall.xdt
@@ -10,6 +10,8 @@
     <add key="AzureCDNToolkit:MediaContainer" xdt:Locator="Match(key)" xdt:Transform="Remove"/>
     <add key="AzureCDNToolkit:SecurityModeEnabled" xdt:Locator="Match(key)" xdt:Transform="Remove"/>
     <add key="AzureCDNToolkit:SecurityToken" xdt:Locator="Match(key)" xdt:Transform="Remove"/>
+    <add key="AzureCDNToolkit:UseRedisCache" value="false" xdt:Locator="Match(key)" xdt:Transform="Remove"/>
+    <add key="AzureCDNToolkit:RedisCacheConnectionString" value="" xdt:Locator="Match(key)" xdt:Transform="Remove"/>
   </appSettings>
 
 </configuration>

--- a/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
@@ -61,6 +61,16 @@
         public string MediaContainer { get; set; }
 
         /// <summary>
+        /// Determines wqhether to use Redis Cache or Local Cache
+        /// </summary>
+        public bool UseRedisCache { get; set; }
+
+        /// <summary>
+        /// Determines wqhether to use Redis Cache or Local Cache
+        /// </summary>
+        public string RedisCacheConnectionString { get; set; }
+
+        /// <summary>
         /// Sets all properties
         /// </summary>
 
@@ -69,7 +79,7 @@
         public void Refresh()
         {
 
-            if ((WebConfigurationManager.AppSettings["AzureCDNToolkit:UseAzureCdnToolkit"] != null))
+            if (WebConfigurationManager.AppSettings["AzureCDNToolkit:UseAzureCdnToolkit"] != null)
             {
                 var useAzureCdnToolkit = bool.Parse(WebConfigurationManager.AppSettings["AzureCDNToolkit:UseAzureCdnToolkit"]);
                 this.UseAzureCdnToolkit = useAzureCdnToolkit;
@@ -84,6 +94,9 @@
             this.CdnUrl = WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnUrl"];
             this.AssetsContainer = WebConfigurationManager.AppSettings["AzureCDNToolkit:AssetsContainer"] ?? "assets";
             this.MediaContainer = WebConfigurationManager.AppSettings["AzureCDNToolkit:MediaContainer"] ?? "media";
+            this.UseRedisCache = WebConfigurationManager.AppSettings["AzureCDNToolkit:UseRedisCache"] != null &&
+                                 bool.Parse(WebConfigurationManager.AppSettings["AzureCDNToolkit:UseRedisCache"]);
+            this.RedisCacheConnectionString = WebConfigurationManager.AppSettings["AzureCDNToolkit:RedisCacheConnectionString"];
         }
 
     }

--- a/src/Our.Umbraco.AzureCDNToolkit/Cache.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/Cache.cs
@@ -1,4 +1,6 @@
-﻿namespace Our.Umbraco.AzureCDNToolkit
+﻿using Umbraco.Core.Logging;
+
+namespace Our.Umbraco.AzureCDNToolkit
 {
     using System;
     using System.Collections.Generic;
@@ -7,29 +9,96 @@
     {
         public static T GetCacheItem<T>(string cacheKey)
         {
+            if (AzureCdnToolkit.Instance.UseRedisCache)
+            {
+                try
+                {
+                    return RedisCache.GetCacheItem<T>(cacheKey);
+                }
+                catch (Exception e)
+                {
+                    // log and fall back to local cache
+                    LogHelper.Error<string>(e.Message, e);
+                }
+            }
+
             return LocalCache.GetLocalCacheItem<T>(cacheKey);
         }
 
         public static void InsertCacheItem<T>(string cacheKey, Func<T> getCacheItem)
         {
-            LocalCache.InsertLocalCacheItem<T>(cacheKey, getCacheItem);
+            if (AzureCdnToolkit.Instance.UseRedisCache)
+            {
+                try
+                {
+                    var item = getCacheItem();
+                    RedisCache.InsertCacheItem(cacheKey, item);
+                    return;
+                }
+                catch (Exception e)
+                {
+                    // log and fall back to local cache
+                    LogHelper.Error<string>(e.Message, e);
+                }
+            }
+
+            LocalCache.InsertLocalCacheItem(cacheKey, getCacheItem);
         }
 
         public static IEnumerable<T> GetCacheItemsByKeySearch<T>(string keyStartsWith)
         {
+            if (AzureCdnToolkit.Instance.UseRedisCache)
+            {
+                try
+                {
+                    return RedisCache.GetCacheItemsByKeySearch<T>(keyStartsWith);
+                }
+                catch (Exception e)
+                {
+                    // log and fall back to local cache
+                    LogHelper.Error<string>(e.Message, e);
+                }
+            }
+
             return LocalCache.GetLocalCacheItemsByKeySearch<T>(keyStartsWith);
         }
 
         public static void ClearCacheItem(string key)
         {
+            if (AzureCdnToolkit.Instance.UseRedisCache)
+            {
+                try
+                {
+                    RedisCache.ClearCacheItem(key);
+                    return;
+                }
+                catch (Exception e)
+                {
+                    // log and fall back to local cache
+                    LogHelper.Error<string>(e.Message, e);
+                }
+            }
+
             LocalCache.ClearLocalCacheItem(key);
         }
 
         public static void ClearCacheByKeySearch(string keyStartsWith)
         {
+            if (AzureCdnToolkit.Instance.UseRedisCache)
+            {
+                try
+                {
+                    RedisCache.ClearCacheByKeySearch(keyStartsWith);
+                    return;
+                }
+                catch (Exception e)
+                {
+                    // log and fall back to local cache
+                    LogHelper.Error<string>(e.Message, e);
+                }
+            }
+
             LocalCache.ClearLocalCacheByKeySearch(keyStartsWith);
         }
-
-
     }
 }

--- a/src/Our.Umbraco.AzureCDNToolkit/Our.Umbraco.AzureCDNToolkit.csproj
+++ b/src/Our.Umbraco.AzureCDNToolkit/Our.Umbraco.AzureCDNToolkit.csproj
@@ -165,6 +165,9 @@
       <HintPath>..\..\packages\UmbracoCms.Core.7.3.8\lib\SQLCE4Umbraco.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
@@ -175,6 +178,7 @@
       <HintPath>..\..\packages\UmbracoCms.Core.7.3.8\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
@@ -294,6 +298,7 @@
     <Compile Include="Models\CachedImagesResponse.cs" />
     <Compile Include="Models\CachedImagesRequest.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
+    <Compile Include="RedisCache.cs" />
     <Compile Include="UrlHelperRenderExtensions.cs" />
     <Compile Include="ImageCropperBaseExtensions.cs" />
     <Compile Include="Models\CachedImage.cs" />

--- a/src/Our.Umbraco.AzureCDNToolkit/Our.Umbraco.AzureCDNToolkit.csproj.DotSettings
+++ b/src/Our.Umbraco.AzureCDNToolkit/Our.Umbraco.AzureCDNToolkit.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/Our.Umbraco.AzureCDNToolkit/RedisCache.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/RedisCache.cs
@@ -1,0 +1,72 @@
+﻿namespace Our.Umbraco.AzureCDNToolkit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+    using StackExchange.Redis;
+
+    public class RedisCache
+    {
+        private static readonly Lazy<ConnectionMultiplexer> LazyConnection = new Lazy<ConnectionMultiplexer>(() =>
+        {
+            return ConnectionMultiplexer.Connect(AzureCdnToolkit.Instance.RedisCacheConnectionString);
+        });
+
+        public static ConnectionMultiplexer Connection => LazyConnection.Value;
+
+        public static IDatabase Db => Connection.GetDatabase();
+
+        public static T GetCacheItem<T>(string cacheKey)
+        {
+            var cacheItem = Db.StringGet(cacheKey);
+
+            if (cacheItem.HasValue)
+            {
+                return JsonConvert.DeserializeObject<T>(cacheItem.ToString());
+            }
+
+            return default(T);
+        }
+
+        public static void InsertCacheItem<T>(string cacheKey, T item)
+        {
+            string cacheValue = JsonConvert.SerializeObject(item);
+
+            Db.StringSet(cacheKey, cacheValue);
+        }
+
+        public static IEnumerable<T> GetCacheItemsByKeySearch<T>(string keyStartsWith)
+        {
+            var endpoints = Connection.GetEndPoints();
+            var server = Connection.GetServer(endpoints.First());
+            var keys = server.Keys(pattern: keyStartsWith + "*");
+
+            return keys.Select(key => JsonConvert.DeserializeObject<T>(Db.StringGet(key).ToString())).ToList();
+        }
+
+        public static void ClearCacheItem(string cacheKey)
+        {
+            Db.KeyDelete(cacheKey);
+        }
+
+        public static void ClearCache()
+        {
+            var endpoints = Connection.GetEndPoints();
+            var server = Connection.GetServer(endpoints.First());
+            server.FlushAllDatabases();
+        }
+
+        public static void ClearCacheByKeySearch(string keyStartsWith)
+        {
+            var endpoints = Connection.GetEndPoints();
+            var server = Connection.GetServer(endpoints.First());
+            var keys = server.Keys(pattern: keyStartsWith + "*");
+
+            foreach (var key in keys)
+            {
+                Db.KeyDelete(key);
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
@@ -312,7 +312,7 @@
                     delegateAction();
                     return;
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     if (retry >= 5)
                     {

--- a/src/Our.Umbraco.AzureCDNToolkit/packages.config
+++ b/src/Our.Umbraco.AzureCDNToolkit/packages.config
@@ -38,6 +38,7 @@
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="semver" version="1.1.2" targetFramework="net45" requireReinstallation="true" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net45" />
   <package id="UmbracoCms.Core" version="7.3.8" targetFramework="net45" />
   <package id="UrlRewritingNet" version="2.0.7" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />

--- a/tests/Our.Umbraco.AzureCDNToolkit.Tests/Our.Umbraco.AzureCDNToolkit.Tests.csproj
+++ b/tests/Our.Umbraco.AzureCDNToolkit.Tests/Our.Umbraco.AzureCDNToolkit.Tests.csproj
@@ -265,7 +265,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RedisCacheTests.cs" />
     <Compile Include="UrlHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/Our.Umbraco.AzureCDNToolkit.Tests/Our.Umbraco.AzureCDNToolkit.Tests.csproj
+++ b/tests/Our.Umbraco.AzureCDNToolkit.Tests/Our.Umbraco.AzureCDNToolkit.Tests.csproj
@@ -166,6 +166,9 @@
       <HintPath>..\..\packages\UmbracoCms.Core.7.4.3\lib\SQLCE4Umbraco.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
@@ -176,6 +179,7 @@
       <HintPath>..\..\packages\UmbracoCms.Core.7.4.3\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
@@ -261,6 +265,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="RedisCacheTests.cs" />
     <Compile Include="UrlHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/Our.Umbraco.AzureCDNToolkit.Tests/RedisCacheTests.cs
+++ b/tests/Our.Umbraco.AzureCDNToolkit.Tests/RedisCacheTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Our.Umbraco.AzureCDNToolkit.Tests
+{
+    [TestFixture]
+    public class RedisCacheTests
+    {
+        [Test]
+        public void TestGetCacheItem()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+            
+            var stringToSet = "Test value";
+            var cacheKey = Guid.NewGuid().ToString();
+
+            // add one item to ensure something is there to flush
+            RedisCache.InsertCacheItem(cacheKey, stringToSet);
+
+            var cacheItem = RedisCache.GetCacheItem<string>(cacheKey);
+
+            Assert.IsNotNull(cacheItem);
+        }
+
+        [Test]
+        public void TestInsertCacheItem()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+            var endpoints = RedisCache.Connection.GetEndPoints();
+            var server = RedisCache.Connection.GetServer(endpoints.First());
+            var itemsBeforeInsert = server.DatabaseSize();
+            var cacheKey = Guid.NewGuid().ToString();
+
+            RedisCache.InsertCacheItem(cacheKey, "Test value");
+
+            var itemsAfterInsert = server.DatabaseSize();
+
+            Assert.AreNotEqual(itemsBeforeInsert, itemsAfterInsert);
+        }
+
+        [Test]
+        public void TestGetCacheItemsByKeySearch()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+            var cacheKey = Guid.NewGuid().ToString();
+            var cacheKeySub = cacheKey.Substring(0, 8);
+
+            RedisCache.InsertCacheItem(cacheKey, "Test value");
+
+            var item = RedisCache.GetCacheItemsByKeySearch<string>(cacheKeySub).FirstOrDefault();
+
+            Assert.IsNotNull(item);
+        }
+
+        [Test]
+        public void TestClearCache()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+
+            var endpoints = RedisCache.Connection.GetEndPoints();
+            var server = RedisCache.Connection.GetServer(endpoints.First());
+
+            // add one item to ensure something is there to flush
+            RedisCache.Db.StringSet(Guid.NewGuid().ToString(), "Test value");
+
+            var keysBeforeFlush = server.DatabaseSize();
+            server.FlushAllDatabases();
+            var keysAfterFlush = server.DatabaseSize();
+
+            Assert.AreNotEqual(keysBeforeFlush, keysAfterFlush);
+        }
+
+        [Test]
+        public void TestClearCacheItem()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+            var cacheKey = Guid.NewGuid().ToString();
+            var stringToSet = "Test value";
+
+            RedisCache.InsertCacheItem(cacheKey, stringToSet);
+
+            var insertedItem = RedisCache.GetCacheItem<string>(cacheKey);
+
+            Assert.AreEqual(insertedItem, stringToSet);
+            
+            RedisCache.ClearCacheItem(cacheKey);
+
+            insertedItem = RedisCache.GetCacheItem<string>(cacheKey);
+
+            Assert.IsNull(insertedItem);
+        }
+        
+        [Test]
+        public void TestClearCacheByKeySearch()
+        {
+            AzureCdnToolkit.Instance.Refresh();
+
+            // insert some items that all start with the same string
+            var cacheKey = Guid.NewGuid().ToString().Substring(0, 8);
+
+            for (var i = 0; i < 10; i++)
+            {
+                var uniqueCacheKey = cacheKey + Guid.NewGuid();
+                RedisCache.InsertCacheItem(uniqueCacheKey, "Test value");
+            }
+
+            var itemsBeforeDelete = RedisCache.GetCacheItemsByKeySearch<string>(cacheKey);
+
+            Assert.AreEqual(itemsBeforeDelete.Count(), 10);
+
+            RedisCache.ClearCacheByKeySearch(cacheKey);
+
+            var itemsAfterDelete = RedisCache.GetCacheItemsByKeySearch<string>(cacheKey);
+
+            Assert.AreNotEqual(itemsBeforeDelete.Count(), itemsAfterDelete.Count());
+        }
+    }
+}

--- a/tests/Our.Umbraco.AzureCDNToolkit.Tests/app.config
+++ b/tests/Our.Umbraco.AzureCDNToolkit.Tests/app.config
@@ -6,6 +6,8 @@
     <add key="AzureCDNToolkit:CdnPackageVersion" value="0.0.1" />
     <add key="AzureCDNToolkit:AssetsContainer" value="assets" />
     <add key="AzureCDNToolkit:MediaContainer" value="media" />
+    <add key="AzureCDNToolkit:UseRedisCache" value="true" />
+    <add key="AzureCDNToolkit:RedisCacheConnectionString" value="" />
   </appSettings>  
   <system.data>
     <DbProviderFactories>

--- a/tests/Our.Umbraco.AzureCDNToolkit.Tests/packages.config
+++ b/tests/Our.Umbraco.AzureCDNToolkit.Tests/packages.config
@@ -32,6 +32,7 @@
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="semver" version="1.1.2" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net45" />
   <package id="UmbracoCms.Core" version="7.4.3" targetFramework="net45" />
   <package id="UrlRewritingNet" version="2.0.7" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />


### PR DESCRIPTION
I've added the ability to use a Redis cache instead of the default local cache. The idea is to move away from having multiple caches (if you are running more than 1 instance i.e. scaled out) and to stop the app from clearing the cache when a change is detected to the config or assemblies.

I've tested this on my environment and it seems to work, and I've added some tests for the RedisCache class.

It's set up to fall back to local cache if for whatever reason it can't connect to the Redis Cache by just checking for a config setting. This seemed like a good option without doing any architectural changes to the solution (to interface the Cache and inject whichever one you want to use).