### PR TITLE
Added null check for crops that do not exist.

### DIFF
--- a/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
@@ -220,6 +220,11 @@
 
         internal static IHtmlString UrlToCdnUrl(string cropUrl, bool htmlEncode, string currentDomain = null)
         {
+            if (string.IsNullOrEmpty(cropUrl))
+            {
+                return new HtmlString(string.Empty);
+            }
+
             // If toolkit disabled return orginal string
             if (!AzureCdnToolkit.Instance.UseAzureCdnToolkit)
             {


### PR DESCRIPTION
On a couple of client sites, enabling the Azure CDN Toolkit in the web.config resulted in the site not loading at all and eventually timing out. On closer inspection this was due to the use of non-existent crop names in the views on the sites. Adding a null check as per this pull request fixed the issue and meant that the sites loaded correctly.