### PR TITLE
Ability to override the default value for the HttpWebRequest Timeout property

### DIFF
--- a/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
@@ -61,6 +61,13 @@
         public string MediaContainer { get; set; }
 
         /// <summary>
+        /// The timeout in milliseconds used when connecting to the cdn
+        /// The default value for the <see cref="System.Net.HttpWebRequest"/> is 100 seconds
+        /// so this is specified as the default value here
+        /// </summary>
+        public int CdnConnectionTimeout { get; set; } = 100 * 1000;
+
+        /// <summary>
         /// Sets all properties
         /// </summary>
 
@@ -68,7 +75,6 @@
 
         public void Refresh()
         {
-
             if ((WebConfigurationManager.AppSettings["AzureCDNToolkit:UseAzureCdnToolkit"] != null))
             {
                 var useAzureCdnToolkit = bool.Parse(WebConfigurationManager.AppSettings["AzureCDNToolkit:UseAzureCdnToolkit"]);
@@ -84,6 +90,14 @@
             this.CdnUrl = WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnUrl"];
             this.AssetsContainer = WebConfigurationManager.AppSettings["AzureCDNToolkit:AssetsContainer"] ?? "assets";
             this.MediaContainer = WebConfigurationManager.AppSettings["AzureCDNToolkit:MediaContainer"] ?? "media";
+
+            if (!string.IsNullOrWhiteSpace(WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnConnectionTimeout"]))
+            {
+                if (int.TryParse(WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnConnectionTimeout"], out int cdnConnectionTimeout))
+                {
+                    CdnConnectionTimeout = cdnConnectionTimeout;
+                }
+            }
         }
 
     }

--- a/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/AzureCdnToolkit.cs
@@ -93,7 +93,8 @@
 
             if (!string.IsNullOrWhiteSpace(WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnConnectionTimeout"]))
             {
-                if (int.TryParse(WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnConnectionTimeout"], out int cdnConnectionTimeout))
+                int cdnConnectionTimeout = 0;
+                if (int.TryParse(WebConfigurationManager.AppSettings["AzureCDNToolkit:CdnConnectionTimeout"], out cdnConnectionTimeout))
                 {
                     CdnConnectionTimeout = cdnConnectionTimeout;
                 }

--- a/src/Our.Umbraco.AzureCDNToolkit/Events/UmbracoEvents.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/Events/UmbracoEvents.cs
@@ -25,7 +25,12 @@
         private void ImageProcessingModule_ValidatingRequest(object sender, ImageProcessor.Web.Helpers.ValidatingRequestEventArgs args)
         {
             var securityToken = WebConfigurationManager.AppSettings["AzureCDNToolkit:SecurityToken"];
-            var securityModeEnabled = bool.Parse(WebConfigurationManager.AppSettings["AzureCDNToolkit:SecurityModeEnabled"]);
+            var securityModeEnabled = false;
+            
+            if (!bool.TryParse(WebConfigurationManager.AppSettings["AzureCDNToolkit:SecurityModeEnabled"], out securityModeEnabled))
+            {
+                securityModeEnabled = false;
+            }
 
             if (securityModeEnabled && !string.IsNullOrWhiteSpace(args.QueryString) && !string.IsNullOrEmpty(securityToken))
             {

--- a/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
@@ -264,6 +264,7 @@
                     TryFiveTimes(() =>
                     {
                         var request = (HttpWebRequest)WebRequest.Create(absoluteCropPath);
+                        request.Timeout = AzureCdnToolkit.Instance.CdnConnectionTimeout;
                         request.Method = "HEAD";
                         using (var response = (HttpWebResponse)request.GetResponse())
                         {

--- a/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
+++ b/src/Our.Umbraco.AzureCDNToolkit/UrlHelperRenderExtensions.cs
@@ -82,7 +82,7 @@
 
         public static IHtmlString ResolveCdn(this UrlHelper urlHelper, string path, bool asset = true, bool htmlEncode = true)
         {
-            return ResolveCdn(urlHelper, path, AzureCdnToolkit.Instance.CdnPackageVersion, asset, htmlEncode:htmlEncode);
+            return ResolveCdn(urlHelper, path, AzureCdnToolkit.Instance.CdnPackageVersion, asset, htmlEncode: htmlEncode);
         }
 
         // Special version of the method with fallback image for TinyMce converter
@@ -166,7 +166,7 @@
 
                 if (asset && !path.InvariantContains("/media/"))
                 {
-                   cdnPath = string.Format("{0}/{1}", AzureCdnToolkit.Instance.CdnUrl, AzureCdnToolkit.Instance.AssetsContainer);
+                    cdnPath = string.Format("{0}/{1}", AzureCdnToolkit.Instance.CdnUrl, AzureCdnToolkit.Instance.AssetsContainer);
                 }
                 else
                 {
@@ -228,8 +228,11 @@
             // If toolkit disabled return orginal string
             if (!AzureCdnToolkit.Instance.UseAzureCdnToolkit)
             {
+                LogHelper.Info(typeof(UrlHelperRenderExtensions), "AzureCdnToolkit is disabled");
                 return new HtmlString(cropUrl);
             }
+
+            LogHelper.Info(typeof(UrlHelperRenderExtensions), "AzureCdnToolkit is enabled");
 
             if (string.IsNullOrEmpty(currentDomain))
             {
@@ -260,29 +263,61 @@
                         absoluteCropPath = string.Format("{0}&securitytoken={1}", absoluteCropPath, securityToken);
                     }
 
-                    // Retry five times before giving up to account for networking issues
-                    TryFiveTimes(() =>
+                    // lazy load the image
+                    Lazy<string> LazyLoadCdnImage = new Lazy<string>(() =>
                     {
-                        var request = (HttpWebRequest)WebRequest.Create(absoluteCropPath);
-                        request.Timeout = AzureCdnToolkit.Instance.CdnConnectionTimeout;
-                        request.Method = "HEAD";
-                        using (var response = (HttpWebResponse)request.GetResponse())
+                        string result = null;
+
+                        try
                         {
-                            var responseCode = response.StatusCode;
-                            if (responseCode.Equals(HttpStatusCode.OK))
+
+                            // parse the image through the handler directly
+
+                            // HttpContext.Current
+
+
+
+                            // Retry five times before giving up to account for networking issues
+                            TryFiveTimes(() =>
                             {
-                                var absoluteUri = response.ResponseUri.AbsoluteUri;
-                                newCachedImage.CacheUrl = absoluteUri;
-
-                                // this is to mark URLs returned direct to Blob by ImageProcessor as not fully resolved
-                                newCachedImage.Resolved = absoluteUri.InvariantContains(AzureCdnToolkit.Instance.CdnUrl);
-
-                                Cache.InsertCacheItem<CachedImage>(cacheKey, () => newCachedImage);
-                                fullUrlPath = response.ResponseUri.AbsoluteUri;
-                            }
+                                var request = (HttpWebRequest)WebRequest.Create(absoluteCropPath);
+                                request.Timeout = AzureCdnToolkit.Instance.CdnConnectionTimeout;
+                                request.Method = "HEAD";
+                                using (var response = (HttpWebResponse)request.GetResponse())
+                                {
+                                    var responseCode = response.StatusCode;
+                                    if (responseCode.Equals(HttpStatusCode.OK))
+                                    {
+                                        result = response.ResponseUri.AbsoluteUri;
+                                    }
+                                }
+                            });
                         }
-                    });
+                        catch(Exception ex)
+                        {
+                            LogHelper.Error(typeof(UrlHelperRenderExtensions), "Error resolving media url from the CDN", ex);
 
+                            // we have tried 5 times and failed so let's cache the normal address
+                            newCachedImage = new CachedImage { WebUrl = cropUrl };
+                            newCachedImage.Resolved = false;
+                            newCachedImage.CacheUrl = cropUrl;
+                            Cache.InsertCacheItem<CachedImage>(cacheKey, () => newCachedImage);
+
+                            result = cropUrl;
+                        }
+
+                        newCachedImage.CacheUrl = result;
+                        // this is to mark URLs returned direct to Blob by ImageProcessor as not fully resolved
+                        newCachedImage.Resolved = fullUrlPath.InvariantContains(AzureCdnToolkit.Instance.CdnUrl);
+                        Cache.InsertCacheItem<CachedImage>(cacheKey, () => newCachedImage);
+
+                        return result;
+
+                    },
+                    System.Threading.LazyThreadSafetyMode.PublicationOnly);
+
+
+                    fullUrlPath = LazyLoadCdnImage.Value;
                 }
                 else
                 {


### PR DESCRIPTION
Resolved an issue where an Azure App Service failed to start correctly due the default 100 second timeout value for the HttpWebRequest